### PR TITLE
feat: use supabase for demo user creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@tanstack/react-table": "^8.21.3",
     "autoprefixer": "^10.4.21",
     "axios": "^1.10.0",
+    "@supabase/supabase-js": "^2.45.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/scripts/create-demo-users.ts
+++ b/scripts/create-demo-users.ts
@@ -1,7 +1,9 @@
-import { PrismaClient } from '@prisma/client'
+import { createClient } from '@supabase/supabase-js'
 import bcrypt from 'bcryptjs'
 
-const prisma = new PrismaClient()
+const supabaseUrl = process.env.SUPABASE_URL!
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+const supabase = createClient(supabaseUrl, supabaseServiceRoleKey)
 
 async function createDemoUsers() {
   try {
@@ -9,58 +11,93 @@ async function createDemoUsers() {
     const hashedPassword = await bcrypt.hash('password123', 12)
 
     // Créer l'utilisateur de démo
-    const demoUser = await prisma.user.upsert({
-      where: { email: 'user@demo.com' },
-      update: {},
-      create: {
-        email: 'user@demo.com',
-        telephone: '+22501020304',
-        nom: 'Demo',
-        prenom: 'User',
-        password: hashedPassword,
-        role: 'USER'
-      }
-    })
+    const { data: demoUser, error: demoUserError } = await supabase
+      .from('users')
+      .upsert(
+        {
+          email: 'user@demo.com',
+          telephone: '+22501020304',
+          nom: 'Demo',
+          prenom: 'User',
+          password: hashedPassword,
+          role: 'USER'
+        },
+        { onConflict: 'email' }
+      )
+      .select()
+      .single()
+    if (demoUserError) throw demoUserError
 
     // Créer l'assureur de démo
-    const demoInsurer = await prisma.user.upsert({
-      where: { email: 'assureur@demo.com' },
-      update: {},
-      create: {
-        email: 'assureur@demo.com',
-        telephone: '+22501020305',
+    const { data: demoInsurerUser, error: demoInsurerUserError } =
+      await supabase
+        .from('users')
+        .upsert(
+          {
+            email: 'assureur@demo.com',
+            telephone: '+22501020305',
+            nom: 'Demo',
+            prenom: 'Assureur',
+            password: hashedPassword,
+            role: 'INSURER'
+          },
+          { onConflict: 'email' }
+        )
+        .select()
+        .single()
+    if (demoInsurerUserError) throw demoInsurerUserError
+
+    const { error: insurerError } = await supabase.from('insurers').upsert(
+      {
+        userId: demoInsurerUser.id,
         nom: 'Demo',
         prenom: 'Assureur',
-        password: hashedPassword,
-        role: 'INSURER'
-      }
-    })
+        email: 'assureur@demo.com',
+        telephone: '+22501020305',
+        nomEntreprise: 'Demo Assurance',
+        adresseEntreprise: 'Abidjan',
+        siegeSocial: 'Abidjan',
+        numeroRegistre: 'REG12345',
+        numeroAgrement: 'AGR67890',
+        domaineActivite: 'Assurance',
+        anneeExperience: '5',
+        nombreEmployes: '10'
+      },
+      { onConflict: 'email' }
+    )
+    if (insurerError) throw insurerError
 
     // Créer l'administrateur de démo
-    const demoAdmin = await prisma.user.upsert({
-      where: { email: 'admin@demo.com' },
-      update: {},
-      create: {
-        email: 'admin@demo.com',
-        telephone: '+22501020306',
-        nom: 'Demo',
-        prenom: 'Admin',
-        password: hashedPassword,
-        role: 'ADMIN'
-      }
-    })
+    const { data: demoAdmin, error: demoAdminError } = await supabase
+      .from('users')
+      .upsert(
+        {
+          email: 'admin@demo.com',
+          telephone: '+22501020306',
+          nom: 'Demo',
+          prenom: 'Admin',
+          password: hashedPassword,
+          role: 'ADMIN'
+        },
+        { onConflict: 'email' }
+      )
+      .select()
+      .single()
+    if (demoAdminError) throw demoAdminError
 
     console.log('Utilisateurs de démo créés avec succès :')
     console.log('Utilisateur:', demoUser.email, 'Rôle:', demoUser.role)
-    console.log('Assureur:', demoInsurer.email, 'Rôle:', demoInsurer.role)
+    console.log(
+      'Assureur:',
+      demoInsurerUser.email,
+      'Rôle:',
+      demoInsurerUser.role
+    )
     console.log('Administrateur:', demoAdmin.email, 'Rôle:', demoAdmin.role)
     console.log('Mot de passe pour tous: password123')
-
   } catch (error) {
     console.error('Erreur lors de la création des utilisateurs de démo:', error)
-  } finally {
-    await prisma.$disconnect()
   }
 }
-
 createDemoUsers()
+


### PR DESCRIPTION
## Summary
- switch demo user script from Prisma to Supabase inserts
- add Supabase client dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ba9f24c5c832da4c22184a24adc82