### PR TITLE
Add Supabase environment variables to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Base de données
 # Remplacer par la chaîne de connexion Supabase
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL="https://xxx.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="public-anon-key"
+SUPABASE_SERVICE_ROLE_KEY="service-role-key"
 
 # NextAuth.js
 NEXTAUTH_SECRET="votre-secret-par-defaut-a-changer-en-production"


### PR DESCRIPTION
## Summary
- add Supabase environment variable examples
- keep DATABASE_URL placeholder for Prisma

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Parsing error: Merge conflict marker encountered)


------
https://chatgpt.com/codex/tasks/task_e_689bb31b7680832d960b0d00aeb7195a