### PR TITLE
fix: correct Supabase offer table name

### DIFF
--- a/prisma/seed/supabase-seed.ts
+++ b/prisma/seed/supabase-seed.ts
@@ -143,7 +143,7 @@ async function main() {
 
     const offersWithInsurer = entry.offers.map((o) => ({ ...o, insurerId: insurer.id }))
     const { error: offersError } = await supabase
-      .from('insuranceOffers')
+      .from('InsuranceOffer')
       .insert(offersWithInsurer)
     if (offersError) throw offersError
   }


### PR DESCRIPTION
## Summary
- fix seeding script to use `InsuranceOffer` table name

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in src/lib/supabase.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689bb31c7e1c832db9cb3a3f39be0a2d