### PR TITLE
refactor: replace prisma with supabase in routes

### DIFF
--- a/src/app/api/admin/quotes/route.ts
+++ b/src/app/api/admin/quotes/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import supabase from '@/lib/supabase'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,11 +14,18 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const quotes = await prisma.quote.findMany({
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: quotes, error } = await supabase
+      .from('Quote')
+      .select('*')
+      .order('createdAt', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching quotes:', error)
+      return NextResponse.json(
+        { success: false, error: 'Une erreur est survenue lors de la récupération des devis' },
+        { status: 500 }
+      )
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import supabase from '@/lib/supabase'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,21 +14,18 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const users = await prisma.user.findMany({
-      select: {
-        id: true,
-        nom: true,
-        prenom: true,
-        email: true,
-        telephone: true,
-        role: true,
-        createdAt: true,
-        updatedAt: true
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: users, error } = await supabase
+      .from('users')
+      .select('id, nom, prenom, email, telephone, role, createdAt, updatedAt')
+      .order('createdAt', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching users:', error)
+      return NextResponse.json(
+        { success: false, error: 'Une erreur est survenue lors de la récupération des utilisateurs' },
+        { status: 500 }
+      )
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/insurer/offers/route.ts
+++ b/src/app/api/insurer/offers/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import supabase from '@/lib/supabase'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,18 +14,18 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const offers = await prisma.insuranceOffer.findMany({
-      include: {
-        insurer: {
-          select: {
-            name: true
-          }
-        }
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: offers, error } = await supabase
+      .from('InsuranceOffer')
+      .select('*, insurer(name)')
+      .order('createdAt', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching offers:', error)
+      return NextResponse.json(
+        { success: false, error: 'Une erreur est survenue lors de la récupération des offres' },
+        { status: 500 }
+      )
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/user/quotes/route.ts
+++ b/src/app/api/user/quotes/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
-import { PrismaClient } from '@prisma/client'
-
-const prisma = new PrismaClient()
+import supabase from '@/lib/supabase'
 
 export async function GET(request: NextRequest) {
   try {
@@ -16,29 +14,28 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const quotes = await prisma.quote.findMany({
-      where: {
-        userId: session.user?.id
-      },
-      include: {
-        quoteOffers: {
-          include: {
-            offer: {
-              include: {
-                insurer: {
-                  select: {
-                    name: true
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: quotes, error } = await supabase
+      .from('Quote')
+      .select(`
+        *,
+        quoteOffers(
+          *,
+          offer(
+            *,
+            insurer(name)
+          )
+        )
+      `)
+      .eq('userId', session.user?.id)
+      .order('createdAt', { ascending: false })
+
+    if (error) {
+      console.error('Error fetching user quotes:', error)
+      return NextResponse.json(
+        { success: false, error: 'Une erreur est survenue lors de la récupération des devis' },
+        { status: 500 }
+      )
+    }
 
     return NextResponse.json({
       success: true,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,25 +1,13 @@
-
 import { createClient } from '@supabase/supabase-js'
 
 export const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
-
-export default supabase
-=======
-
-import { createClient } from "@supabase/supabase-js"
-
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!,
   {
     auth: {
-      persistSession: false
-    }
+      persistSession: false,
+    },
   }
 )
 
-);
-
+export default supabase


### PR DESCRIPTION
## Summary
- refactor user and admin API routes to use Supabase instead of Prisma
- refactor insurer routes to use Supabase instead of Prisma
- fix supabase client configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb31daa14832db2d7c8e447d50062