### PR TITLE
feat: add default supabase export

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -7,3 +7,5 @@ export const supabase = createClient(
   { auth: { persistSession: false } }
 );
 
+export default supabase;
+


### PR DESCRIPTION
## Summary
- add default export for Supabase client

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Type 'string' is not assignable to type 'Easing | Easing[] | undefined', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689bb70c0490832db2ca0da8cca83597