### PR TITLE
refactor: replace db queries with supabase

### DIFF
--- a/src/app/api/comparateur/quotes/route.ts
+++ b/src/app/api/comparateur/quotes/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
-const db: any = supabase
 
 interface QuoteRequest {
   // Profil conducteur
@@ -43,35 +42,40 @@ export async function POST(request: NextRequest) {
     const quoteReference = `DEV-${Date.now()}-${Math.random().toString(36).substr(2, 9).toUpperCase()}`
     
     // Créer ou récupérer l'utilisateur
-    let user = null
-    if (body.email) {
-      user = await db.user.findUnique({
-        where: { email: body.email }
-      })
-    }
-    
+    let { data: user } = body.email
+      ? await supabase.from('users').select('*').eq('email', body.email).maybeSingle()
+      : { data: null }
+
     if (!user && body.telephone) {
-      user = await db.user.findUnique({
-        where: { telephone: body.telephone }
-      })
+      const res = await supabase
+        .from('users')
+        .select('*')
+        .eq('telephone', body.telephone)
+        .maybeSingle()
+      user = res.data
     }
-    
+
     if (!user) {
-      user = await db.user.create({
-        data: {
+      const { data: createdUser, error: userError } = await supabase
+        .from('users')
+        .insert({
           email: body.email || null,
           telephone: body.telephone,
           nom: body.nom,
           prenom: body.prenom,
           dateNaissance: body.dateNaissance ? new Date(body.dateNaissance) : null,
           datePermis: body.datePermis ? new Date(body.datePermis) : null
-        }
-      })
+        })
+        .select()
+        .single()
+      if (userError) throw userError
+      user = createdUser
     }
     
     // Créer le devis
-    const quote = await db.quote.create({
-      data: {
+    const { data: quote, error: quoteError } = await supabase
+      .from('Quote')
+      .insert({
         userId: user.id,
         quoteReference,
         nom: body.nom,
@@ -98,8 +102,11 @@ export async function POST(request: NextRequest) {
         preferenceContact: body.preferenceContact,
         contactMethod: body.preferenceContact,
         status: 'pending'
-      }
-    })
+      })
+      .select()
+      .single()
+
+    if (quoteError) throw quoteError
     
     // Ajouter les offres au devis
     if (body.selectedOffers && body.selectedOffers.length > 0) {
@@ -109,9 +116,7 @@ export async function POST(request: NextRequest) {
         priceAtQuote: 0 // Sera calculé plus tard
       }))
       
-      await db.quoteOffer.createMany({
-        data: quoteOffersData
-      })
+      await supabase.from('QuoteOffer').insert(quoteOffersData)
     }
     
     return NextResponse.json({
@@ -140,68 +145,32 @@ export async function GET(request: NextRequest) {
     
     if (reference) {
       // Récupérer un devis par sa référence
-      const quote = await db.quote.findUnique({
-        where: { quoteReference: reference },
-        include: {
-          user: {
-            select: {
-              id: true,
-              nom: true,
-              prenom: true,
-              email: true,
-              telephone: true
-            }
-          },
-          quoteOffers: {
-            include: {
-              offer: {
-                include: {
-                  insurer: true,
-                  offerFeatures: true
-                }
-              }
-            }
-          }
-        }
-      })
-      
-      if (!quote) {
+      const { data: quote, error } = await supabase
+        .from('Quote')
+        .select(`*, user:users(id, nom, prenom, email, telephone), quoteOffers:QuoteOffer(*, offer:InsuranceOffer(*, insurer:insurers(*), offerFeatures:OfferFeature(*)))`)
+        .eq('quoteReference', reference)
+        .single()
+
+      if (error) {
         return NextResponse.json(
           { success: false, error: 'Quote not found' },
           { status: 404 }
         )
       }
-      
-      return NextResponse.json({
-        success: true,
-        quote
-      })
+      return NextResponse.json({ success: true, quote })
     }
     
     if (userId) {
       // Récupérer tous les devis d'un utilisateur
-      const quotes = await db.quote.findMany({
-        where: { userId },
-        include: {
-          quoteOffers: {
-            include: {
-              offer: {
-                include: {
-                  insurer: true
-                }
-              }
-            }
-          }
-        },
-        orderBy: {
-          createdAt: 'desc'
-        }
-      })
-      
-      return NextResponse.json({
-        success: true,
-        quotes
-      })
+      const { data: quotes, error } = await supabase
+        .from('Quote')
+        .select(`*, quoteOffers:QuoteOffer(*, offer:InsuranceOffer(*, insurer:insurers(*)))`)
+        .eq('userId', userId)
+        .order('createdAt', { ascending: false })
+
+      if (error) throw error
+
+      return NextResponse.json({ success: true, quotes })
     }
     
     return NextResponse.json(

--- a/src/app/api/formulaire-assure/route.ts
+++ b/src/app/api/formulaire-assure/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
-const db: any = supabase
 
 export async function POST(request: NextRequest) {
   try {
@@ -35,25 +34,26 @@ export async function POST(request: NextRequest) {
     }
 
     // Créer ou mettre à jour l'assuré dans la base de données
-    const assure = await db.assure.upsert({
-      where: { email },
-      update: {
-        nom,
-        prenom,
-        telephone,
-        isWhatsApp,
-        updatedAt: new Date()
-      },
-      create: {
-        nom,
-        prenom,
-        email,
-        telephone,
-        isWhatsApp,
-        createdAt: new Date(),
-        updatedAt: new Date()
-      }
-    })
+    const { data: assure, error } = await supabase
+      .from('assures')
+      .upsert(
+        {
+          nom,
+          prenom,
+          email,
+          telephone,
+          isWhatsApp,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        { onConflict: 'email' }
+      )
+      .select()
+      .single()
+
+    if (error) {
+      throw error
+    }
 
     return NextResponse.json({
       message: 'Informations de l\'assuré enregistrées avec succès',


### PR DESCRIPTION
## Summary
- migrate API routes from Prisma-style `db` calls to Supabase query builder
- unify CRUD logic across user, analytics, quotes and admin endpoints
- ensure dashboard stats and options workflows operate via Supabase

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb70d23cc832dac61e7bb8839ee29