### PR TITLE
fix: correct insurance offer query

### DIFF
--- a/src/app/api/insurance-offers/route.ts
+++ b/src/app/api/insurance-offers/route.ts
@@ -3,8 +3,8 @@ import supabase from '@/lib/supabase'
 export async function GET() {
   try {
     const { data: offers, error } = await supabase
-      .from('insuranceOffer')
-      .select('id, description, monthlyPrice, coverageLevel, isActive, createdAt, insurer:insurer(nomEntreprise)')
+      .from('InsuranceOffer')
+      .select('id, description, monthlyPrice, coverageLevel, isActive, createdAt, insurer:insurers(nomEntreprise)')
       .order('createdAt', { ascending: false })
 
     if (error) {


### PR DESCRIPTION
## Summary
- query `InsuranceOffer` table
- fix insurer relationship alias for offers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run type-check` *(fails: TS errors)*
- `npx tsx -e "process.env.NEXT_PUBLIC_SUPABASE_URL='http://localhost:54321'; process.env.SUPABASE_SERVICE_ROLE_KEY='test'; import('./src/app/api/insurance-offers/route.ts').then(async m => { const res = await m.GET(); console.log('status', res.status); console.log('body', await res.json()); }).catch(err => console.error(err));"` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689bbcacb938832d8eb7ff7dca6dd87a