### PR TITLE
Use public Supabase URL for seeding scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ npm start
 
 Open [http://localhost:3000](http://localhost:3000) to see your application running.
 
+## 🗃️ Database Seed
+
+After exporting the required Supabase environment variables, you can seed the database:
+
+```bash
+export NEXT_PUBLIC_SUPABASE_URL="https://<your-project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<your-service-role-key>"
+node scripts/supabase-seed.ts
+```
+
+This populates your Supabase project with demo data.
+
 ## 🤖 Powered by Z.ai
 
 This scaffold is optimized for use with [Z.ai](https://chat.z.ai) - your AI assistant for:

--- a/scripts/create-demo-users.ts
+++ b/scripts/create-demo-users.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 import bcrypt from 'bcryptjs'
 
-const supabaseUrl = process.env.SUPABASE_URL!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
 const supabase = createClient(supabaseUrl, supabaseServiceRoleKey)
 

--- a/scripts/supabase-seed.ts
+++ b/scripts/supabase-seed.ts
@@ -4,7 +4,7 @@ const dotenv = require('dotenv')
 
 dotenv.config()
 
-const supabaseUrl = process.env.SUPABASE_URL
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 if (!supabaseUrl || !supabaseServiceKey) {


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_SUPABASE_URL` in Supabase scripts
- document seeding command in README

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`
- `npm run type-check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bbf649688832db04b4ad9de70324c