### PR TITLE
fix: import NextResponse and correct Quote table

### DIFF
--- a/src/app/api/devis-admin/route.ts
+++ b/src/app/api/devis-admin/route.ts
@@ -1,9 +1,10 @@
 
+import { NextResponse } from 'next/server'
 import supabase from '@/lib/supabase'
 export async function GET() {
   try {
     const { data: quotes, error } = await supabase
-      .from('quote')
+      .from('Quote')
       .select('id, quoteReference, telephone, energie, puissanceFiscale, status, createdAt, user(*), assure(*), quoteOffers(selected, priceAtQuote, offer(*, insurer(*)))')
       .order('createdAt', { ascending: false })
 


### PR DESCRIPTION
## Summary
- import NextResponse in devis-admin API route
- query Quote table instead of quote

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bc21a62f4832db2a48b494c8f619c